### PR TITLE
Try fixing Darwin import to use Foundation

### DIFF
--- a/Sources/Clef.swift
+++ b/Sources/Clef.swift
@@ -8,6 +8,8 @@
 
 #if os(Linux)
     import Glibc
+#elseif os(iOS) || os(watchOS) || os(tvOS) || os(OSX)
+    import Foundation
 #else
     import Darwin.C
 #endif

--- a/Sources/MeasureDurationValidator.swift
+++ b/Sources/MeasureDurationValidator.swift
@@ -8,6 +8,8 @@
 
 #if os(Linux)
     import Glibc
+#elseif os(iOS) || os(watchOS) || os(tvOS) || os(OSX)
+    import Foundation
 #else
     import Darwin.C
 #endif


### PR DESCRIPTION
Need to use Foundation instead of Darwin for it to work properly when being included as a dependency in an iOS project (see MusicNotationKit)